### PR TITLE
Configure PHP upload parameters.

### DIFF
--- a/config/uploads.ini
+++ b/config/uploads.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 64M
+upload_max_filesize = 64M
+post_max_size = 64M
+max_execution_time = 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
        - "${WP_PORT}:80"
      volumes:
        - "./wordpress:/var/www/html"
+       - "./config/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini"
      restart: always
      environment:
        WORDPRESS_DB_HOST: db:${DB_PORT}


### PR DESCRIPTION
Adds upload.ini with parameters for file uploads in PHP.
Could be used when uploading WordPress plugins, bigger images, etc.